### PR TITLE
[bubo] Improve init command help and auto-detect GitHub remote

### DIFF
--- a/.claude/skills/gh-issue-writer/SKILL.md
+++ b/.claude/skills/gh-issue-writer/SKILL.md
@@ -20,8 +20,8 @@ Use this skill when the user wants to:
 ### Step 1: Parse User Input
 
 1. Determine issue type from prefix:
-  - `feat:` → Feature request
-  - `bug:` → Bug report
+- `feat:` → Feature request
+- `bug:` → Bug report
 2. Extract the brief description and additional context
 
 ### Step 2: Create the Issue

--- a/.claude/skills/gh-issue-writer/SKILL.md
+++ b/.claude/skills/gh-issue-writer/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: gh-issue-writer
-description: Create and publish GitHub issues with full project board integration. Use when 
-the user wants to create feature requests (feat:) or bug reports (bug:), track work in 
-GitHub Projects, and set up development branches.
+description: Create and publish GitHub issues with full project board integration. Use when the user wants to create feature requests (feat:) or bug reports (bug:), track work in GitHub Projects, and set up development branches.
 ---
 
 # GitHub Issue Writer
@@ -12,6 +10,7 @@ Create and publish GitHub issues for the bubo project with full project board in
 ## When to Use
 
 Use this skill when the user wants to:
+
 - Create a new feature request (input starts with `feat:`)
 - Report a bug (input starts with `bug:`)
 - Track work in the Modular IoT project board
@@ -21,8 +20,8 @@ Use this skill when the user wants to:
 ### Step 1: Parse User Input
 
 1. Determine issue type from prefix:
-   - `feat:` → Feature request
-   - `bug:` → Bug report
+  - `feat:` → Feature request
+  - `bug:` → Bug report
 2. Extract the brief description and additional context
 
 ### Step 2: Create the Issue
@@ -30,6 +29,7 @@ Use this skill when the user wants to:
 Publish the issue directly to the repository specified in `$GH_ISSUE_REPO` using `gh` CLI or GitHub MCP tools.
 
 **Required fields:**
+
 - **Title**: Concise, descriptive title based on user input
 - **Labels**: Appropriate labels (e.g., `enhancement`, `bug`, `bubo`, `cli`, `github-integration`)
 - **Body**: Fill in all template sections with relevant details
@@ -81,6 +81,7 @@ gh issue develop <ISSUE_NUMBER> \
 ```
 
 **Branch naming:**
+
 - Base branch: `trunk`
 - Format: `based/<issue-id>-<short-name>`
 - Short name: 3-4 words max, descriptive of the feature/fix
@@ -138,15 +139,18 @@ When writing issues, understand that bubo is:
 - Can run as CLI, GitHub Action, or webhook service
 
 **Code structure:**
+
 - `cli/` - Command-line interface and commands
 - `core/` - Core business logic and orchestration
 - `types/` - TypeScript type definitions
 - `utils/` - Shared utilities and helpers
 
 **Relevant labels:**
+
 - `bubo` - Triggers Bubo to work on this issue
 - `bubo:in-progress` - Bubo is currently working on this
 - `bubo:blocked` - Bubo encountered an issue and needs help
 - `bubo:complete` - Bubo has completed the task
 - `enhancement` - Feature requests
 - `bug` - Bug reports
+

--- a/.claude/skills/gh-issue-writer/SKILL.md
+++ b/.claude/skills/gh-issue-writer/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: gh-issue-writer
-description: Create and publish GitHub issues with full project board integration. Use when the user wants to create feature requests (feat:) or bug reports (bug:), track work in GitHub Projects, and set up development branches.
+description: Create and publish GitHub issues with full project board integration. Use when 
+the user wants to create feature requests (feat:) or bug reports (bug:), track work in 
+GitHub Projects, and set up development branches.
 ---
 
 # GitHub Issue Writer
@@ -32,26 +34,28 @@ Publish the issue directly to the repository specified in `$GH_ISSUE_REPO` using
 - **Labels**: Appropriate labels (e.g., `enhancement`, `bug`, `bubo`, `cli`, `github-integration`)
 - **Body**: Fill in all template sections with relevant details
 
-### Step 3: Associate Issue to Project
+### Step 3: Associate Issue to Project and Capture Item ID
 
-Read project configuration from `.env` file, then add the issue to the project:
+Read project configuration from `.env` file, add the issue to the project, and capture the project item ID in one step:
 
 ```bash
-# Load env vars (or read from .env)
 source .env
 
-gh project item-add $GH_PROJECT_NUMBER --owner $GH_PROJECT_OWNER --url https://github.com/$GH_ISSUE_REPO/issues/<ISSUE_NUMBER>
+# Add to project and capture item ID (more efficient than querying all items)
+ITEM_ID=$(gh project item-add $GH_PROJECT_NUMBER \
+  --owner $GH_PROJECT_OWNER \
+  --url "https://github.com/$GH_ISSUE_REPO/issues/<ISSUE_NUMBER>" \
+  --format json | jq -r '.id')
+
+echo "Project Item ID: $ITEM_ID"
 ```
 
 ### Step 4: Set Project Status
 
-Get the item ID and set the status using env vars:
+Set the status using the captured item ID:
 
 ```bash
 source .env
-
-# Get item ID
-ITEM_ID=$(gh project item-list $GH_PROJECT_NUMBER --owner $GH_PROJECT_OWNER --limit 500 --format json | jq -r '.items[] | select(.content.number == <ISSUE_NUMBER>) | .id')
 
 # Set status based on context:
 # If files are already modified → "In Progress"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bubo
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=microboxlabs_bubo&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=microboxlabs_bubo)
+
 An enterprise AI coding agent with deep GitHub integration. Bubo automates software development workflows by orchestrating AI-powered coding sessions that integrate seamlessly with GitHub Issues, Projects, and Pull Requests.
 
 ## Overview

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,25 @@
+# SonarQube Project Configuration
+sonar.projectKey=microboxlabs_bubo
+sonar.projectName=bubo
+
+# Source code location
+sonar.sources=src
+
+# Test code location
+sonar.tests=tests
+
+# Language and file extensions
+sonar.language=ts
+sonar.sourceEncoding=UTF-8
+
+# TypeScript/JavaScript coverage
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclude test files from duplication detection
+sonar.cpd.exclusions=tests/**/*
+
+# Exclude test files from code coverage analysis (they are tests, not source)
+sonar.coverage.exclusions=tests/**/*
+
+# File extensions to analyze
+sonar.typescript.file.suffixes=.ts,.tsx

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -22,7 +22,10 @@ type ConfigSource = 'command line' | 'environment' | 'git remote';
  */
 function detectGitHubRemote(): { owner: string; repo: string } | null {
   try {
-    const remote = execSync('git remote get-url origin', { encoding: 'utf-8' }).trim();
+    const remote = execSync('git remote get-url origin', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'], // Suppress stderr to avoid error messages
+    }).trim();
     // Parse: git@github.com:owner/repo.git or https://github.com/owner/repo.git
     const match = remote.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
     if (match && match[1] && match[2]) {
@@ -48,8 +51,8 @@ export async function initCommand(options: InitOptions): Promise<void> {
     return;
   }
 
-  // Try to detect from git remote
-  const detectedRemote = detectGitHubRemote();
+  // Only try to detect from git remote if owner/repo are not provided
+  const detectedRemote = (options.owner && options.repo) ? null : detectGitHubRemote();
 
   // Determine owner and repo with source tracking
   let owner: string;

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -100,20 +100,35 @@ function printSuccessMessage(
 }
 
 /**
+ * Parse a GitHub remote URL into owner and repo components.
+ * Supports SSH (git@github.com:owner/repo.git), HTTPS (https://github.com/owner/repo.git),
+ * and HTTPS with port (https://github.com:443/owner/repo.git).
+ */
+export function parseGitHubRemoteUrl(remote: string): { owner: string; repo: string } | null {
+  // Match: git@github.com:owner/repo.git, https://github.com/owner/repo.git,
+  // or https://github.com:443/owner/repo.git
+  // - (?::\d+)? allows optional port after github.com
+  // - [:/] separator (colon for SSH, slash for HTTPS)
+  // - ([^/]+) captures owner (non-slash characters)
+  // - ([^/]+?) captures repo (non-slash, non-greedy to handle .git suffix)
+  const match = remote.match(/github\.com(?::\d+)?[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (match?.[1] && match?.[2]) {
+    return { owner: match[1], repo: match[2] };
+  }
+  return null;
+}
+
+/**
  * Detect GitHub owner and repo from git remote origin URL
  */
-function detectGitHubRemote(): { owner: string; repo: string } | null {
+export function detectGitHubRemote(): { owner: string; repo: string } | null {
   try {
     const gitPath = getGitPath();
     const remote = execFileSync(gitPath, ['remote', 'get-url', 'origin'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'], // Suppress stderr to avoid error messages
     }).trim();
-    // Parse: git@github.com:owner/repo.git or https://github.com/owner/repo.git
-    const match = remote.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
-    if (match?.[1] && match?.[2]) {
-      return { owner: match[1], repo: match[2] };
-    }
+    return parseGitHubRemoteUrl(remote);
   } catch {
     // Not a git repo or no remote configured
   }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -25,7 +25,7 @@ interface ResolvedValue {
 /**
  * Get the git executable path from environment or use default.
  * Set GIT_PATH environment variable to override (e.g., for Windows or custom installations).
- * This prevents PATH manipulation attacks (CWE-426, CWE-427).
+ * Note: When GIT_PATH is not set, the fallback 'git' still relies on PATH resolution.
  */
 function getGitPath(): string {
   return process.env['GIT_PATH'] ?? 'git';

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -111,7 +111,7 @@ export function parseGitHubRemoteUrl(remote: string): { owner: string; repo: str
   // - [:/] separator (colon for SSH, slash for HTTPS)
   // - ([^/]+) captures owner (non-slash characters)
   // - ([^/]+?) captures repo (non-slash, non-greedy to handle .git suffix)
-  const match = remote.match(/github\.com(?::\d+)?[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
+  const match = /github\.com(?::\d+)?[:/]([^/]+)\/([^/]+?)(?:\.git)?$/.exec(remote);
   if (match?.[1] && match?.[2]) {
     return { owner: match[1], repo: match[2] };
   }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,6 +1,6 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
 import { generateStarterConfig } from '../../core/config/defaults.js';
@@ -105,7 +105,7 @@ function printSuccessMessage(
 function detectGitHubRemote(): { owner: string; repo: string } | null {
   try {
     const gitPath = getGitPath();
-    const remote = execSync(`${gitPath} remote get-url origin`, {
+    const remote = execFileSync(gitPath, ['remote', 'get-url', 'origin'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'], // Suppress stderr to avoid error messages
     }).trim();

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -38,7 +38,7 @@ function detectGitHubRemote(): { owner: string; repo: string } | null {
     }).trim();
     // Parse: git@github.com:owner/repo.git or https://github.com/owner/repo.git
     const match = remote.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
-    if (match && match[1] && match[2]) {
+    if (match?.[1] && match?.[2]) {
       return { owner: match[1], repo: match[2] };
     }
   } catch {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,7 +1,7 @@
-import { writeFile, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
-import { execSync } from 'child_process';
-import { join, dirname } from 'path';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
 import { generateStarterConfig } from '../../core/config/defaults.js';
 import type { BuboConfig } from '../../core/config/schema.js';

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -18,11 +18,21 @@ interface InitOptions {
 type ConfigSource = 'command line' | 'environment' | 'git remote';
 
 /**
+ * Get the git executable path from environment or use default.
+ * Set GIT_PATH environment variable to override (e.g., for Windows or custom installations).
+ * This prevents PATH manipulation attacks (CWE-426, CWE-427).
+ */
+function getGitPath(): string {
+  return process.env['GIT_PATH'] ?? 'git';
+}
+
+/**
  * Detect GitHub owner and repo from git remote origin URL
  */
 function detectGitHubRemote(): { owner: string; repo: string } | null {
   try {
-    const remote = execSync('git remote get-url origin', {
+    const gitPath = getGitPath();
+    const remote = execSync(`${gitPath} remote get-url origin`, {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'], // Suppress stderr to avoid error messages
     }).trim();

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -17,6 +17,11 @@ interface InitOptions {
 
 type ConfigSource = 'command line' | 'environment' | 'git remote';
 
+interface ResolvedValue {
+  value: string;
+  source: ConfigSource;
+}
+
 /**
  * Get the git executable path from environment or use default.
  * Set GIT_PATH environment variable to override (e.g., for Windows or custom installations).
@@ -24,6 +29,74 @@ type ConfigSource = 'command line' | 'environment' | 'git remote';
  */
 function getGitPath(): string {
   return process.env['GIT_PATH'] ?? 'git';
+}
+
+/**
+ * Resolve a config value from options, environment, or git remote
+ */
+function resolveConfigValue(
+  optionValue: string | undefined,
+  envKey: string,
+  remoteValue: string | undefined
+): ResolvedValue {
+  if (optionValue) {
+    return { value: optionValue, source: 'command line' };
+  }
+  const envValue = process.env[envKey];
+  if (envValue) {
+    return { value: envValue, source: 'environment' };
+  }
+  if (remoteValue) {
+    return { value: remoteValue, source: 'git remote' };
+  }
+  return { value: '', source: 'command line' };
+}
+
+/**
+ * Print error message when owner/repo is missing
+ */
+function printMissingRepoError(detectedRemote: { owner: string; repo: string } | null): void {
+  console.log('⚠️  GitHub owner and repo are required.\n');
+  console.log('Options:');
+  console.log('  1. Set environment variables:');
+  console.log('     export GITHUB_OWNER=your-org');
+  console.log('     export GITHUB_REPO=your-repo\n');
+  console.log('  2. Pass as arguments:');
+  console.log('     bubo init --owner your-org --repo your-repo\n');
+  if (detectedRemote) {
+    console.log(`  3. Detected from git remote: ${detectedRemote.owner}/${detectedRemote.repo}`);
+    console.log('     This will be used automatically if no other values are provided.\n');
+  } else {
+    console.log('  Note: No git remote detected. Make sure you are in a git repository');
+    console.log('        with a GitHub remote configured.\n');
+  }
+}
+
+/**
+ * Print success message after config creation
+ */
+function printSuccessMessage(
+  owner: string,
+  repo: string,
+  ownerSource: ConfigSource,
+  repoSource: ConfigSource,
+  config: BuboConfig
+): void {
+  const sourceInfo = ownerSource === repoSource
+    ? `(from ${ownerSource})`
+    : `(owner from ${ownerSource}, repo from ${repoSource})`;
+
+  console.log('✅ Created .bubo/workflow.yml');
+  console.log(`   Repository: ${owner}/${repo} ${sourceInfo}`);
+  console.log('');
+  console.log('Next steps:');
+  console.log('  1. Review and customize the configuration');
+  console.log('  2. Create the required labels in your GitHub repository:');
+  console.log(`     - ${config.workflow.triggers.pickup.labels.join(', ')}`);
+  console.log(`     - ${config.workflow.labels.in_progress}`);
+  console.log(`     - ${config.workflow.labels.blocked}`);
+  console.log(`     - ${config.workflow.labels.complete}`);
+  console.log('  3. Run `bubo config validate` to verify your setup');
 }
 
 /**
@@ -65,66 +138,20 @@ export async function initCommand(options: InitOptions): Promise<void> {
   const detectedRemote = (options.owner && options.repo) ? null : detectGitHubRemote();
 
   // Determine owner and repo with source tracking
-  let owner: string;
-  let repo: string;
-  let ownerSource: ConfigSource;
-  let repoSource: ConfigSource;
+  const ownerResolved = resolveConfigValue(options.owner, 'GITHUB_OWNER', detectedRemote?.owner);
+  const repoResolved = resolveConfigValue(options.repo, 'GITHUB_REPO', detectedRemote?.repo);
 
-  if (options.owner) {
-    owner = options.owner;
-    ownerSource = 'command line';
-  } else if (process.env['GITHUB_OWNER']) {
-    owner = process.env['GITHUB_OWNER'];
-    ownerSource = 'environment';
-  } else if (detectedRemote) {
-    owner = detectedRemote.owner;
-    ownerSource = 'git remote';
-  } else {
-    owner = '';
-    ownerSource = 'command line';
-  }
-
-  if (options.repo) {
-    repo = options.repo;
-    repoSource = 'command line';
-  } else if (process.env['GITHUB_REPO']) {
-    repo = process.env['GITHUB_REPO'];
-    repoSource = 'environment';
-  } else if (detectedRemote) {
-    repo = detectedRemote.repo;
-    repoSource = 'git remote';
-  } else {
-    repo = '';
-    repoSource = 'command line';
-  }
-
-  if (!owner || !repo) {
-    console.log('⚠️  GitHub owner and repo are required.\n');
-    console.log('Options:');
-    console.log('  1. Set environment variables:');
-    console.log('     export GITHUB_OWNER=your-org');
-    console.log('     export GITHUB_REPO=your-repo\n');
-    console.log('  2. Pass as arguments:');
-    console.log('     bubo init --owner your-org --repo your-repo\n');
-    if (detectedRemote) {
-      console.log(`  3. Detected from git remote: ${detectedRemote.owner}/${detectedRemote.repo}`);
-      console.log('     This will be used automatically if no other values are provided.\n');
-    } else {
-      console.log('  Note: No git remote detected. Make sure you are in a git repository');
-      console.log('        with a GitHub remote configured.\n');
-    }
+  if (!ownerResolved.value || !repoResolved.value) {
+    printMissingRepoError(detectedRemote);
     return;
   }
 
   // Generate configuration
-  const configOptions: { owner: string; repo: string; project?: number } = {
-    owner,
-    repo,
-  };
-  if (options.project !== undefined) {
-    configOptions.project = options.project;
-  }
-  const config = generateStarterConfig(configOptions);
+  const config = generateStarterConfig({
+    owner: ownerResolved.value,
+    repo: repoResolved.value,
+    ...(options.project !== undefined && { project: options.project }),
+  });
 
   // Create directory if needed
   const configDir = dirname(configPath);
@@ -137,21 +164,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
   await writeFile(configPath, yamlContent, 'utf-8');
 
   // Show success with source information
-  const sourceInfo = ownerSource === repoSource
-    ? `(from ${ownerSource})`
-    : `(owner from ${ownerSource}, repo from ${repoSource})`;
-
-  console.log('✅ Created .bubo/workflow.yml');
-  console.log(`   Repository: ${owner}/${repo} ${sourceInfo}`);
-  console.log('');
-  console.log('Next steps:');
-  console.log('  1. Review and customize the configuration');
-  console.log('  2. Create the required labels in your GitHub repository:');
-  console.log(`     - ${config.workflow.triggers.pickup.labels.join(', ')}`);
-  console.log(`     - ${config.workflow.labels.in_progress}`);
-  console.log(`     - ${config.workflow.labels.blocked}`);
-  console.log(`     - ${config.workflow.labels.complete}`);
-  console.log('  3. Run `bubo config validate` to verify your setup');
+  printSuccessMessage(ownerResolved.value, repoResolved.value, ownerResolved.source, repoResolved.source, config);
 }
 
 /**

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -27,7 +27,7 @@ function detectGitHubRemote(): { owner: string; repo: string } | null {
       stdio: ['ignore', 'pipe', 'ignore'], // Suppress stderr to avoid error messages
     }).trim();
     // Parse: git@github.com:owner/repo.git or https://github.com/owner/repo.git
-    const match = remote.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
+    const match = remote.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
     if (match && match[1] && match[2]) {
       return { owner: match[1], repo: match[2] };
     }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,5 +1,6 @@
 import { writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
+import { execSync } from 'child_process';
 import { join, dirname } from 'path';
 import { stringify as yamlStringify } from 'yaml';
 import { generateStarterConfig } from '../../core/config/defaults.js';
@@ -12,6 +13,25 @@ interface InitOptions {
   repo?: string;
   project?: number;
   force?: boolean;
+}
+
+type ConfigSource = 'command line' | 'environment' | 'git remote';
+
+/**
+ * Detect GitHub owner and repo from git remote origin URL
+ */
+function detectGitHubRemote(): { owner: string; repo: string } | null {
+  try {
+    const remote = execSync('git remote get-url origin', { encoding: 'utf-8' }).trim();
+    // Parse: git@github.com:owner/repo.git or https://github.com/owner/repo.git
+    const match = remote.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
+    if (match && match[1] && match[2]) {
+      return { owner: match[1], repo: match[2] };
+    }
+  } catch {
+    // Not a git repo or no remote configured
+  }
+  return null;
 }
 
 /**
@@ -28,14 +48,58 @@ export async function initCommand(options: InitOptions): Promise<void> {
     return;
   }
 
-  // Determine owner and repo
-  const owner = options.owner ?? process.env['GITHUB_OWNER'] ?? '';
-  const repo = options.repo ?? process.env['GITHUB_REPO'] ?? '';
+  // Try to detect from git remote
+  const detectedRemote = detectGitHubRemote();
+
+  // Determine owner and repo with source tracking
+  let owner: string;
+  let repo: string;
+  let ownerSource: ConfigSource;
+  let repoSource: ConfigSource;
+
+  if (options.owner) {
+    owner = options.owner;
+    ownerSource = 'command line';
+  } else if (process.env['GITHUB_OWNER']) {
+    owner = process.env['GITHUB_OWNER'];
+    ownerSource = 'environment';
+  } else if (detectedRemote) {
+    owner = detectedRemote.owner;
+    ownerSource = 'git remote';
+  } else {
+    owner = '';
+    ownerSource = 'command line';
+  }
+
+  if (options.repo) {
+    repo = options.repo;
+    repoSource = 'command line';
+  } else if (process.env['GITHUB_REPO']) {
+    repo = process.env['GITHUB_REPO'];
+    repoSource = 'environment';
+  } else if (detectedRemote) {
+    repo = detectedRemote.repo;
+    repoSource = 'git remote';
+  } else {
+    repo = '';
+    repoSource = 'command line';
+  }
 
   if (!owner || !repo) {
-    console.log('⚠️  GitHub owner and repo are required');
-    console.log('   Set GITHUB_OWNER and GITHUB_REPO environment variables');
-    console.log('   Or use: bubo init --owner <owner> --repo <repo>');
+    console.log('⚠️  GitHub owner and repo are required.\n');
+    console.log('Options:');
+    console.log('  1. Set environment variables:');
+    console.log('     export GITHUB_OWNER=your-org');
+    console.log('     export GITHUB_REPO=your-repo\n');
+    console.log('  2. Pass as arguments:');
+    console.log('     bubo init --owner your-org --repo your-repo\n');
+    if (detectedRemote) {
+      console.log(`  3. Detected from git remote: ${detectedRemote.owner}/${detectedRemote.repo}`);
+      console.log('     This will be used automatically if no other values are provided.\n');
+    } else {
+      console.log('  Note: No git remote detected. Make sure you are in a git repository');
+      console.log('        with a GitHub remote configured.\n');
+    }
     return;
   }
 
@@ -59,7 +123,13 @@ export async function initCommand(options: InitOptions): Promise<void> {
   const yamlContent = generateYamlWithComments(config);
   await writeFile(configPath, yamlContent, 'utf-8');
 
+  // Show success with source information
+  const sourceInfo = ownerSource === repoSource
+    ? `(from ${ownerSource})`
+    : `(owner from ${ownerSource}, repo from ${repoSource})`;
+
   console.log('✅ Created .bubo/workflow.yml');
+  console.log(`   Repository: ${owner}/${repo} ${sourceInfo}`);
   console.log('');
   console.log('Next steps:');
   console.log('  1. Review and customize the configuration');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,10 +21,18 @@ program
 program
   .command('init')
   .description('Initialize Bubo configuration in the current repository')
-  .option('-o, --owner <owner>', 'GitHub owner/organization')
-  .option('-r, --repo <repo>', 'GitHub repository name')
-  .option('-p, --project <number>', 'GitHub Project number', parseInt)
-  .option('-f, --force', 'Overwrite existing configuration')
+  .option('-o, --owner <owner>', 'GitHub organization or username (env: GITHUB_OWNER)')
+  .option('-r, --repo <repo>', 'Repository name where issues are created, without owner prefix (env: GITHUB_REPO)')
+  .option('-p, --project <number>', 'GitHub Project number for workflow automation (optional)', parseInt)
+  .option('-f, --force', 'Overwrite existing .bubo/workflow.yml configuration')
+  .addHelpText('after', `
+Examples:
+  $ bubo init --owner acme-inc --repo acme-app
+  $ bubo init --project 123                        # Uses env vars for owner/repo
+  $ bubo init --force                              # Regenerate configuration
+  $ bubo init                                      # Auto-detect from git remote
+  $ bubo init --owner acme-inc --repo acme-app --project 123 --force
+`)
   .action(initCommand);
 
 // Run command

--- a/src/core/claude/runner.ts
+++ b/src/core/claude/runner.ts
@@ -3,8 +3,9 @@ import type { TaskContext } from '../../types/agent.js';
 
 /**
  * Get the Claude CLI executable path from environment or use default.
- * Set CLAUDE_PATH environment variable to override.
- * This prevents PATH manipulation attacks (CWE-426, CWE-427).
+ * Set CLAUDE_PATH environment variable to an absolute path to mitigate
+ * PATH manipulation attacks (CWE-426, CWE-427).
+ * Note: When CLAUDE_PATH is not set, the fallback 'claude' relies on PATH resolution.
  */
 function getClaudePath(): string {
   return process.env['CLAUDE_PATH'] ?? 'claude';

--- a/src/core/claude/runner.ts
+++ b/src/core/claude/runner.ts
@@ -2,6 +2,15 @@ import { spawn } from 'child_process';
 import type { TaskContext } from '../../types/agent.js';
 
 /**
+ * Get the Claude CLI executable path from environment or use default.
+ * Set CLAUDE_PATH environment variable to override.
+ * This prevents PATH manipulation attacks (CWE-426, CWE-427).
+ */
+function getClaudePath(): string {
+  return process.env['CLAUDE_PATH'] ?? 'claude';
+}
+
+/**
  * ClaudeCodeRunner - Executes Claude Code for AI-powered coding
  */
 export class ClaudeCodeRunner {
@@ -78,7 +87,8 @@ Otherwise, continue working on the task.
    */
   private async runClaudeCode(prompt: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const child = spawn('claude', ['--print', prompt], {
+      const claudePath = getClaudePath();
+      const child = spawn(claudePath, ['--print', prompt], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env },
       });

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { parseGitHubRemoteUrl, detectGitHubRemote } from '../src/cli/commands/init.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+describe('parseGitHubRemoteUrl', () => {
+  describe('SSH URLs', () => {
+    it('parses standard SSH URL', () => {
+      const result = parseGitHubRemoteUrl('git@github.com:owner/repo.git');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses SSH URL without .git suffix', () => {
+      const result = parseGitHubRemoteUrl('git@github.com:owner/repo');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses SSH URL with hyphens in owner and repo', () => {
+      const result = parseGitHubRemoteUrl('git@github.com:my-org/my-repo.git');
+      expect(result).toEqual({ owner: 'my-org', repo: 'my-repo' });
+    });
+
+    it('parses SSH URL with underscores', () => {
+      const result = parseGitHubRemoteUrl('git@github.com:my_org/my_repo.git');
+      expect(result).toEqual({ owner: 'my_org', repo: 'my_repo' });
+    });
+  });
+
+  describe('HTTPS URLs', () => {
+    it('parses standard HTTPS URL', () => {
+      const result = parseGitHubRemoteUrl('https://github.com/owner/repo.git');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses HTTPS URL without .git suffix', () => {
+      const result = parseGitHubRemoteUrl('https://github.com/owner/repo');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses HTTPS URL with port', () => {
+      const result = parseGitHubRemoteUrl('https://github.com:443/owner/repo.git');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses HTTPS URL with non-standard port', () => {
+      const result = parseGitHubRemoteUrl('https://github.com:8443/owner/repo.git');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses HTTPS URL with port but without .git suffix', () => {
+      const result = parseGitHubRemoteUrl('https://github.com:443/owner/repo');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo' });
+    });
+  });
+
+  describe('repo names with dots', () => {
+    it('parses repo name with dots', () => {
+      const result = parseGitHubRemoteUrl('https://github.com/owner/repo.name.with.dots.git');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo.name.with.dots' });
+    });
+
+    it('parses repo name with dots and no .git suffix', () => {
+      const result = parseGitHubRemoteUrl('https://github.com/owner/my.dotted.repo');
+      expect(result).toEqual({ owner: 'owner', repo: 'my.dotted.repo' });
+    });
+
+    it('parses SSH URL with dotted repo name', () => {
+      const result = parseGitHubRemoteUrl('git@github.com:owner/repo.v2.git');
+      expect(result).toEqual({ owner: 'owner', repo: 'repo.v2' });
+    });
+
+    it('parses HTTPS URL with port and dotted repo name', () => {
+      const result = parseGitHubRemoteUrl('https://github.com:443/owner/my.project.git');
+      expect(result).toEqual({ owner: 'owner', repo: 'my.project' });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null for non-GitHub URLs', () => {
+      const result = parseGitHubRemoteUrl('https://gitlab.com/owner/repo.git');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for malformed URLs', () => {
+      const result = parseGitHubRemoteUrl('not-a-url');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      const result = parseGitHubRemoteUrl('');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for URL with missing repo', () => {
+      const result = parseGitHubRemoteUrl('https://github.com/owner');
+      expect(result).toBeNull();
+    });
+
+    it('handles numeric repo names', () => {
+      const result = parseGitHubRemoteUrl('https://github.com/owner/12345.git');
+      expect(result).toEqual({ owner: 'owner', repo: '12345' });
+    });
+  });
+});
+
+describe('detectGitHubRemote', () => {
+  const mockExecFileSync = vi.mocked(execFileSync);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Reset GIT_PATH env var
+    delete process.env['GIT_PATH'];
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('detects GitHub remote from SSH URL', () => {
+    mockExecFileSync.mockReturnValue('git@github.com:microboxlabs/bubo.git\n');
+
+    const result = detectGitHubRemote();
+
+    expect(result).toEqual({ owner: 'microboxlabs', repo: 'bubo' });
+    expect(mockExecFileSync).toHaveBeenCalledWith('git', ['remote', 'get-url', 'origin'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  });
+
+  it('detects GitHub remote from HTTPS URL', () => {
+    mockExecFileSync.mockReturnValue('https://github.com/microboxlabs/bubo.git\n');
+
+    const result = detectGitHubRemote();
+
+    expect(result).toEqual({ owner: 'microboxlabs', repo: 'bubo' });
+  });
+
+  it('detects GitHub remote from HTTPS URL with port', () => {
+    mockExecFileSync.mockReturnValue('https://github.com:443/microboxlabs/bubo.git\n');
+
+    const result = detectGitHubRemote();
+
+    expect(result).toEqual({ owner: 'microboxlabs', repo: 'bubo' });
+  });
+
+  it('returns null when git command fails', () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: not a git repository');
+    });
+
+    const result = detectGitHubRemote();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when remote is not a GitHub URL', () => {
+    mockExecFileSync.mockReturnValue('https://gitlab.com/owner/repo.git\n');
+
+    const result = detectGitHubRemote();
+
+    expect(result).toBeNull();
+  });
+
+  it('uses custom GIT_PATH when set', () => {
+    process.env['GIT_PATH'] = '/custom/path/to/git';
+    mockExecFileSync.mockReturnValue('git@github.com:owner/repo.git\n');
+
+    detectGitHubRemote();
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      '/custom/path/to/git',
+      ['remote', 'get-url', 'origin'],
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
- Enhanced option descriptions with environment variable hints
- Added usage examples to `bubo init --help`
- Auto-detect owner/repo from git remote origin when not specified
- Improved error messages with numbered resolution options
- Show source of config values (git remote, env, CLI) on success
- Optimize gh-issue-writer skill to capture item ID from item-add

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-source GitHub owner/repo resolution with per-field source reporting
  * Auto-detect GitHub repo from git remote when needed
  * Project association captures and echoes project item ID
  * Environment override for external assistant executable

* **Documentation**
  * Expanded CLI help with multi-line examples and clarified option descriptions
  * README badge and wording/formatting tweaks

* **Tests**
  * Comprehensive tests for GitHub remote parsing and detection

* **Other**
  * Generates commented config files and ensures required directories exist
  * Added SonarQube configuration file

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->