### PR TITLE
fix: replace regex with linear-time parsing to prevent ReDoS (CWE-1333)

### DIFF
--- a/src/core/claude/runner.ts
+++ b/src/core/claude/runner.ts
@@ -131,11 +131,12 @@ Otherwise, continue working on the task.
       };
     }
 
-    const blockedMatch = output.match(/<promise>BLOCKED:\s*(.+?)<\/promise>/);
-    if (blockedMatch) {
+    // Use indexOf-based parsing instead of regex to avoid backtracking DoS (CWE-1333)
+    const blockedReason = this.extractBlockedReason(output);
+    if (blockedReason !== null) {
       return {
         status: 'blocked',
-        message: blockedMatch[1] ?? 'Unknown blocker',
+        message: blockedReason || 'Unknown blocker',
         committed: false,
       };
     }
@@ -145,6 +146,28 @@ Otherwise, continue working on the task.
       message: 'Continuing work on task',
       committed: true,
     };
+  }
+
+  /**
+   * Extract blocked reason using linear-time string parsing.
+   * Avoids regex backtracking vulnerability with overlapping patterns.
+   */
+  private extractBlockedReason(output: string): string | null {
+    const startTag = '<promise>BLOCKED:';
+    const endTag = '</promise>';
+
+    const startIdx = output.indexOf(startTag);
+    if (startIdx === -1) {
+      return null;
+    }
+
+    const contentStart = startIdx + startTag.length;
+    const endIdx = output.indexOf(endTag, contentStart);
+    if (endIdx === -1) {
+      return null;
+    }
+
+    return output.slice(contentStart, endIdx).trim();
   }
 }
 


### PR DESCRIPTION
Replace vulnerable regex /<promise>BLOCKED:\s*(.+?)<\/promise>/ with indexOf-based string parsing in ClaudeCodeRunner.parseOutput().

The original regex had overlapping patterns (\s* and .+?) that could cause O(n²) backtracking on malformed input. The new extractBlockedReason() helper uses indexOf() and slice() for guaranteed O(n) linear time.

Fixes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced blocked status message extraction with improved fallback handling when message content is unavailable.

* **Refactor**
  * Optimized message parsing performance by replacing regex-based extraction with efficient linear-time string processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->